### PR TITLE
Feature/stat field

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,10 @@ from django_stats2.fields import StatField
 
 class MyModel(StatsMixin, models.Model):
      # ... your fields here
+     # Declare the names of your stat fields
+     stat_fields = ['read_count']
 
+     # Declare stat fields
      read_count = StatField()
 ```
 

--- a/django_stats2/mixins.py
+++ b/django_stats2/mixins.py
@@ -7,8 +7,10 @@ class StatsMixin(object):
     Allows a Django model to have some :class:`django_stats2.fields.StatField`
     assigned as attributes.
     """
+    stat_fields = []
+
     def _update_stat_fields(self):
-        for key in dir(self):
+        for key in self.stat_fields:
             try:
                 attr = getattr(self, key)
                 if isinstance(attr, StatField):

--- a/sampleproject/notes/models.py
+++ b/sampleproject/notes/models.py
@@ -10,5 +10,6 @@ class Note(StatsMixin, models.Model):
     title = models.CharField(max_length=128)
     content = models.TextField()
 
+    stat_fields = ['reads', 'edits']
     reads = StatField()
     edits = StatField()

--- a/tests/models.py
+++ b/tests/models.py
@@ -10,5 +10,6 @@ class Note(StatsMixin, models.Model):
     title = models.CharField(max_length=128)
     content = models.TextField()
 
+    stat_fields = ['reads', 'edits']
     reads = StatField()
     edits = StatField()


### PR DESCRIPTION
To avoid iterating through the entire `dir(self)` and performing `getattr()` on every attribute of the object, it will be more efficient to manually declare the attriute names in `self.stat_fields`.
If there is an automatic way to declare these without iterating through as before then please let me know and I will update. 
