### PR TITLE
refactor mixin to use model.__dict__ instead of getattr to find  stat fields

### DIFF
--- a/django_stats2/mixins.py
+++ b/django_stats2/mixins.py
@@ -7,8 +7,16 @@ class StatsMixin(object):
     Allows a Django model to have some :class:`django_stats2.fields.StatField`
     assigned as attributes.
     """
+    def get_stat_fields(self):
+        stat_fields = []
+        model = type(self)
+        for key, value in model.__dict__.items():
+            if isinstance(value, StatField):
+                stat_fields.append(key)
+        return stat_fields
+
     def _update_stat_fields(self):
-        for key in dir(self):
+        for key in self.get_stat_fields():
             try:
                 attr = getattr(self, key)
                 if isinstance(attr, StatField):

--- a/django_stats2/mixins.py
+++ b/django_stats2/mixins.py
@@ -7,7 +7,7 @@ class StatsMixin(object):
     Allows a Django model to have some :class:`django_stats2.fields.StatField`
     assigned as attributes.
     """
-    def get_stat_fields(self):
+    def _get_stat_fields(self):
         stat_fields = []
         model = type(self)
         for key, value in model.__dict__.items():
@@ -16,7 +16,7 @@ class StatsMixin(object):
         return stat_fields
 
     def _update_stat_fields(self):
-        for key in self.get_stat_fields():
+        for key in self._get_stat_fields():
             try:
                 attr = getattr(self, key)
                 if isinstance(attr, StatField):


### PR DESCRIPTION
Alternative approach to https://github.com/fmartingr/django-stats2/pull/4
without the need to manually specifiy stat_fields

Closes #4 
